### PR TITLE
GNOME Shell 40 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,9 +3,10 @@
   "description": "A button to easily open gnome-calculator.\n Credits to extensions.gnome.org/extension/939/display-button/", 
   "name": "Calculator Button", 
   "shell-version": [
-    "3.38"
+    "3.38",
+    "40.0"
   ], 
   "url": "https://github.com/amivaleo/Calculator-Button", 
   "uuid": "calculator-button@amivaleo", 
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
Since this extension only uses panel element from GNOME Shell UI, adding "40.0" to the `shell-version` would be enough.

also bumped to the next version.